### PR TITLE
Add setView to Map

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,9 @@ extern "C" {
     pub fn new_with_element(el: &HtmlElement, options: &JsValue) -> Map;
 
     #[wasm_bindgen(method)]
+    pub fn setView(this: &Map, center: &LatLng, zoom: f64);
+
+    #[wasm_bindgen(method)]
     pub fn getBounds(this: &Map) -> LatLngBounds;
 
     #[wasm_bindgen(method)]


### PR DESCRIPTION
Hi,

Thanks for providing this crate. After experimenting I wasn't able to get the simple examples from https://leafletjs.com/ working. To get it working I needed the setView() method. This PR adds this method to the generated bindings.

Hope you find this useful and accept this addition!