### PR TITLE
Add Path and CircleMarker + missing methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,6 +444,10 @@ extern "C" {
     #[wasm_bindgen(constructor, js_namespace = L)]
     pub fn new_with_options(latlngs: Vec<JsValue>, options: &JsValue) -> Polyline;
 
+    /// [`addLatLng`](https://leafletjs.com/reference-1.7.1.html#polyline-addlatlng)
+    #[wasm_bindgen(method)]
+    pub fn addLatLng(this: &Polyline, latlng: &LatLng);
+
     // Polygon
 
     #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,8 +423,9 @@ extern "C" {
 
     // Polyline
 
+    /// [`Polyline`](https://leafletjs.com/reference-1.7.1.html#polyline)
     #[derive(Debug)]
-    #[wasm_bindgen(extends = Layer)]
+    #[wasm_bindgen(extends = Path)]
     pub type Polyline;
 
     #[wasm_bindgen(constructor, js_namespace = L)]
@@ -495,7 +496,7 @@ extern "C" {
     // Circle
 
     #[derive(Debug)]
-    #[wasm_bindgen(extends = Layer)]
+    #[wasm_bindgen(extends = CircleMarker)]
     pub type Circle;
 
     #[wasm_bindgen(constructor, js_namespace = L)]
@@ -503,6 +504,14 @@ extern "C" {
 
     #[wasm_bindgen(constructor, js_namespace = L)]
     pub fn new_with_options(latlng: &LatLng, options: &JsValue) -> Circle;
+
+    /// [`setRadius`](https://leafletjs.com/reference-1.7.1.html#circle-setradius)
+    #[wasm_bindgen(method)]
+    pub fn setRadius(this: &Circle, radius: f64);
+
+    /// [`getRadius`](https://leafletjs.com/reference-1.7.1.html#circle-getradius)
+    #[wasm_bindgen(method)]
+    pub fn getRadius(this: &Circle) -> f64;
 
     // FeatureGroup
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn getPopup(this: &Layer) -> Popup;
 
-    // Layer Tooltil Methods
+    // Layer Tooltip Methods
 
     /// [`bindTooltip`](https://leafletjs.com/reference-1.7.1.html#layer-bindtooltip)
     #[wasm_bindgen(method)]
@@ -457,6 +457,41 @@ extern "C" {
     #[wasm_bindgen(constructor, js_namespace = L)]
     pub fn new_with_options(bounds: &LatLngBounds, options: &JsValue) -> Rectangle;
 
+    // CircleMarker
+
+    /// [`CirleMarker`](https://leafletjs.com/reference-1.7.1.html#circlemarker)
+    #[derive(Debug)]
+    #[wasm_bindgen(extends = Path)]
+    pub type CircleMarker;
+
+    /// [`Constructor`](https://leafletjs.com/reference-1.7.1.html#circlemarker-l-circlemarker)
+    #[wasm_bindgen(constructor, js_namespace = L)]
+    pub fn new(latlng: &LatLng) -> CircleMarker;
+
+    /// [`Constructor`](https://leafletjs.com/reference-1.7.1.html#circlemarker-l-circlemarker)
+    #[wasm_bindgen(constructor, js_namespace = L)]
+    pub fn new_with_options(latlng: &LatLng, options: &JsValue) -> CircleMarker;
+
+    /// [`toGeoJSON`](https://leafletjs.com/reference-1.7.1.html#circlemarker-togeojson)
+    #[wasm_bindgen(method)]
+    pub fn toGeoJSON(this: &CircleMarker) -> JsValue;
+
+    /// [`setLatLng`](https://leafletjs.com/reference-1.7.1.html#circlemarker-setlanglng)
+    #[wasm_bindgen(method)]
+    pub fn setLatLng(this: &CircleMarker, latlng: &LatLng);
+
+    /// [`getLatLng`](https://leafletjs.com/reference-1.7.1.html#circlemarker-getlatlng)
+    #[wasm_bindgen(method)]
+    pub fn getLatLng(this: &CircleMarker) -> LatLng;
+
+    /// [`setRadius`](https://leafletjs.com/reference-1.7.1.html#circlemarker-setradius)
+    #[wasm_bindgen(method)]
+    pub fn setRadius(this: &CircleMarker, radius: f64);
+
+    /// [`getRadius`](https://leafletjs.com/reference-1.7.1.html#circlemarker-getradius)
+    #[wasm_bindgen(method)]
+    pub fn getRadius(this: &CircleMarker) -> f64;
+
     // Circle
 
     #[derive(Debug)]
@@ -537,4 +572,27 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn addTo(this: &Control, map: &Map);
 
+
+    // Path
+
+    /// [`Path`](https://leafletjs.com/reference-1.7.1.html#path)
+    #[derive(Debug)]
+    #[wasm_bindgen(extends = Layer)]
+    pub type Path;
+
+    /// [`redraw`](https://leafletjs.com/reference-1.7.1.html#path-redraw)
+    #[wasm_bindgen(method)]
+    pub fn redraw(this: &Path);
+
+    /// [`setStyle`](https://leafletjs.com/reference-1.7.1.html#path-setstyle)
+    #[wasm_bindgen(method)]
+    pub fn setStyle(this: &Path, path_options: &JsValue);
+
+    /// [`bringToFront`](https://leafletjs.com/reference-1.7.1.html#path-bringtofront)
+    #[wasm_bindgen(method)]
+    pub fn bringToFront(this: &Path);
+
+    /// [`bringToBack`](https://leafletjs.com/reference-1.7.1.html#path-bringtoback)
+    #[wasm_bindgen(method)]
+    pub fn bringToBack(this: &Path);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,8 +85,14 @@ extern "C" {
     #[wasm_bindgen(extends = Evented)]
     pub type Layer;
 
+    /// [`addTo`](https://leafletjs.com/reference-1.7.1.html#layer-addto)
     #[wasm_bindgen(method)]
     pub fn addTo(this: &Layer, map: &Map);
+
+    /// [`addTo`](https://leafletjs.com/reference-1.7.1.html#layer-addto)
+    #[wasm_bindgen(method)]
+    #[wasm_bindgen(js_name = addTo)]
+    pub fn addTo_LayerGroup(this: &Layer, layerGroup: &LayerGroup);
 
     #[wasm_bindgen(method)]
     pub fn remove(this: &Layer);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,12 @@ extern "C" {
 
     /// [`openPopup`](https://leafletjs.com/reference-1.7.1.html#layer-openpopup)
     #[wasm_bindgen(method)]
-    pub fn openPopup(this: &Layer, latlng: &LatLng);
+    pub fn openPopup(this: &Layer);
+
+    /// [`openPopup`](https://leafletjs.com/reference-1.7.1.html#layer-openpopup)
+    #[wasm_bindgen(method)]
+    #[wasm_bindgen(js_name = openPopup)]
+    pub fn openPopup_with_latlng(this: &Layer, latlng: &LatLng);
 
     /// [`closePopup`](https://leafletjs.com/reference-1.7.1.html#layer-closepopup)
     #[wasm_bindgen(method)]
@@ -328,8 +333,13 @@ extern "C" {
     #[wasm_bindgen(extends = Layer)]
     pub type Marker;
 
+    // [`Marker`](https://leafletjs.com/reference-1.7.1.html#marker-l-marker)
     #[wasm_bindgen(constructor, js_namespace = L)]
-    pub fn new(latlng: &LatLng, options: &JsValue) -> Marker;
+    pub fn new(latlng: &LatLng) -> Marker;
+
+    // [`Marker`](https://leafletjs.com/reference-1.7.1.html#marker-l-marker)
+    #[wasm_bindgen(constructor, js_namespace = L)]
+    pub fn new_with_options(latlng: &LatLng, options: &JsValue) -> Marker;
 
     #[wasm_bindgen(method)]
     pub fn setIcon(this: &Marker, icon: &Icon);


### PR DESCRIPTION
Hi, for a personal project, I needed to implement missing Leaflet methods.

This PR contains the following changes:
* add `Path` and `CircleMarker` with methods
* `Path` extends `Layer`
* `CircleMarker` extends `Path`
* `Circle` extends `CircleMarker`
* `PolyLine` extends `Path`
* add `PolyLine::addLatLng()` method
* add additional `Layer::addTo_LayerGroup()` constructor for adding instances to `LayerGroup`s
* breaking: `Marker::new()` remove options argument, new  `Marker::new_with_options()` that takes the additional options parameter
* breaking: `Layer::openPopup()` argument removed, new `Layer::openPopup_with_latlng()` that takes a `LatLng` as parameter

The naming for the methods with optional arguments orients itself according to the conventions used by wasm-bindgen and other methods in leaflet-rs.

Please let me know if changes are required before this PR can be merged.