### PR TITLE
fix: Added missing inheritance of LayerOptions to PathOptions

### DIFF
--- a/src/shapes/path.rs
+++ b/src/shapes/path.rs
@@ -1,7 +1,7 @@
 use js_sys::Object;
 use wasm_bindgen::prelude::*;
 
-use crate::{create_object_with_properties, Layer};
+use crate::{create_object_with_properties, Layer, LayerOptions};
 
 #[wasm_bindgen]
 extern "C" {
@@ -28,7 +28,7 @@ extern "C" {
 }
 
 create_object_with_properties!(
-    (PathOptions, PathOptions),
+    (PathOptions, PathOptions, LayerOptions),
     (stroke, stroke, bool),
     (color, color, String),
     (weight, weight, f64),


### PR DESCRIPTION
This pull request updates the `src/shapes/path.rs` file to enhance the configuration options for path shapes by introducing support for `LayerOptions` in the `PathOptions` object. This allows path shapes to be created with additional layer-specific options.

Enhancement to path shape options:

* Added `LayerOptions` as a property to the `PathOptions` object, enabling more flexible configuration of path shapes.