### PR TITLE
Add missing iconRetinaUrl property to Icon

### DIFF
--- a/src/icon.rs
+++ b/src/icon.rs
@@ -15,6 +15,7 @@ extern "C" {
 create_object_with_properties!(
     (IconOptions, IconOptions),
     (icon_url, iconUrl, String),
+    (icon_retina_url, iconRetinaUrl, String),
     (icon_size, iconSize, Point),
     (icon_anchor, iconAnchor, Point),
     (popup_anchor, popupAnchor, Point),


### PR DESCRIPTION
Trying to apply what I saw in examples of using custom icons with Leaflet.js, I noticed that `leaflet::IconOptions` was missing a field corresponding to [`iconRetinaUrl`](https://leafletjs.com/reference.html#icon-iconretinaurl).

I assume this was an oversight as simply adding a line to `create_object_with_properties!` seems to do the trick?